### PR TITLE
installation: Instruct users to disable secureboot with virt-manager

### DIFF
--- a/source/_includes/installation/operating_system.md
+++ b/source/_includes/installation/operating_system.md
@@ -266,6 +266,9 @@ _All these can be extended if your usage calls for more resources._
     4. Check the box for “Customize configuration before install”
     5. Select your bridge under “Network Selection”
     6. Under customization select “Overview” -> “Firmware” -> “UEFI x86_64: ...”
+       
+       Make sure to select a non-secureboot version of OVMF (does not contain the word `secure`). E.g `/usr/share/edk2/ovmf/OVMF_CODE.fd`.
+       
     7. Click "Add Hardware" (bottom left), and select "Channel"
     8. Select device type: "unix"
     9. Select name: "org.qemu.guest_agent.0"


### PR DESCRIPTION


## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->

Modern distros ship a variety of UEFI binaries and selecting a secureboot one leads to an un-bootable VM as there are no secure-boot keys enrolled by default for the home-assistant OS.

Note explicitly that virt-manager users should pick the non-secureboot variant.

## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [X] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [ ] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: 
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [X] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
